### PR TITLE
fix: bump markdown ver for 3.14 compatibility

### DIFF
--- a/.github/workflows/jamstack.yml
+++ b/.github/workflows/jamstack.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Set up Python 3 🐍
         uses: actions/setup-python@v2
         with:
-          python-version: '3.8' # Version range or exact version of a Python version to use, using SemVer's version range syntax
+          python-version: '3.14' # Version range or exact version of a Python version to use, using SemVer's version range syntax
           architecture: 'x64' # optional x64 or x86. Defaults to x64 if not specified
 
       - name: Update PIP ✨

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ itsdangerous==1.1.0
 jamstack==0.1.0
 Jinja2==2.11.3
 livereload==2.6.3
-Markdown==3.3.4
+Markdown==3.10.2
 MarkupSafe==1.1.1
 six==1.15.0
 tornado==6.1


### PR DESCRIPTION
Markdown was pinned to an old version incompatible with later Python versions. Now it should work for Python 3.12 and up :)